### PR TITLE
🐛 fix: merging of two similarly keyed mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 keywords = ["configuration", "root", "management", "strategy", "settings"]
 
-dependencies = ["tomli; python_version < '3.11'", "python-dotenv~=1.0.0"]
+dependencies = ["deepmerge~=1.1.0", "tomli; python_version < '3.11'", "python-dotenv~=1.0.0"]
 
 [project.optional-dependencies]
 yaml = ["PyYAML"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ black==22.10.0
 build==0.10.0
 click==8.1.3
 coverage==6.5.0
+deepmerge==1.1.0
 flake8==5.0.4
 iniconfig==1.1.1
 isort==5.10.1


### PR DESCRIPTION
# Overview
This sets out to fix issue #10.  We found that merging two sources with similar mappings would cause the destruction of the mapping from the previously processed source. The use case we found this in was having a config with some secret values, then populating just the secret values from a secure store.

# Specifics
* Add `deepmerge` package to handle merging of two mappings properly
* Add some additional typing for added type safety
* Fix a test that would fail due to vscode using `TEST_` environment variables for it's test runner